### PR TITLE
Small compile fixes

### DIFF
--- a/mobat/include/recorder/config.hpp
+++ b/mobat/include/recorder/config.hpp
@@ -1,7 +1,7 @@
 #ifndef CONFIG_HPP
 #define CONFIG_HPP
 
-#include </usr/include/alsa/asoundlib.h>
+#include <alsa/asoundlib.h>
 #include <utility>
 
 class Config {

--- a/mobat/include/recorder/device.hpp
+++ b/mobat/include/recorder/device.hpp
@@ -1,7 +1,7 @@
 #ifndef DEVICE_HPP
 #define DEVICE_HPP
 
-#include </usr/include/alsa/asoundlib.h>
+#include <alsa/asoundlib.h>
 #include <iostream>
 
 struct device {

--- a/mobat/include/recorder/recorder.hpp
+++ b/mobat/include/recorder/recorder.hpp
@@ -4,7 +4,7 @@
 #include "config.hpp"
 #include "device.hpp"
 // requires libasound2-dev
-#include </usr/include/alsa/asoundlib.h>
+#include <alsa/asoundlib.h>
 #include <vector>
 
 class Recorder {

--- a/mobat/src/signaltrans/signal_analyzer.cpp
+++ b/mobat/src/signaltrans/signal_analyzer.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include <chrono>
+#include <numeric>
 
 SignalAnalyzer::
 SignalAnalyzer() : fft_window_size_( ({configurator().getUint("fft_window_size");  }) ),


### PR DESCRIPTION
Hi, I tried compiling your code on [NixOS](https://nixos.org/) and compile failed for 2 reasons:
1. [accumulate is not a member of std](http://stackoverflow.com/questions/7899237/function-for-calculating-the-mean-of-an-array-double-using-accumulate)
2. the path of the alsa library is different (and one can't assume it is standard). That way it works for me and should for other, too (if you can verify it)

If anybody runs in those problems, here are the fixes